### PR TITLE
refactor: replace bare except clauses with specific exceptions

### DIFF
--- a/gimpopenvino/plugins/fastsd_ov/fastsd_ov.py
+++ b/gimpopenvino/plugins/fastsd_ov/fastsd_ov.py
@@ -374,7 +374,7 @@ class FastSDPlugin(Gimp.PlugIn):
             s.sendall(b"kill")
 
             print("stable-diffusion model server killed")
-        except:
+        except (ConnectionError, OSError) as e:
             print("No stable-diffusion model server found to kill")
 
         if sys.platform == "win32":

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_canny_edge.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_canny_edge.py
@@ -135,7 +135,8 @@ class ControlNetCannyEdge(DiffusionPipeline):
 
         try:
             self.tokenizer = CLIPTokenizer.from_pretrained(model,local_files_only=True)
-        except:
+        except Exception as e:
+            # Fallback to downloading tokenizer if local files not available
             self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
             self.tokenizer.save_pretrained(model)
 

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_cannyedge_advanced.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_cannyedge_advanced.py
@@ -133,7 +133,8 @@ class ControlNetCannyEdgeAdvanced(DiffusionPipeline):
         
         try:
             self.tokenizer = CLIPTokenizer.from_pretrained(model,local_files_only=True)
-        except:
+        except Exception as e:
+            # Fallback to downloading tokenizer if local files not available
             self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
             self.tokenizer.save_pretrained(model)
 

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose.py
@@ -165,7 +165,8 @@ class ControlNetOpenPose(DiffusionPipeline):
 
         try:
             self.tokenizer = CLIPTokenizer.from_pretrained(model,local_files_only=True)
-        except:
+        except Exception as e:
+            # Fallback to downloading tokenizer if local files not available
             self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
             self.tokenizer.save_pretrained(model)
             

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose_advanced.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose_advanced.py
@@ -163,7 +163,8 @@ class ControlNetOpenPoseAdvanced(DiffusionPipeline):
         
         try:
             self.tokenizer = CLIPTokenizer.from_pretrained(model,local_files_only=True)
-        except:
+        except Exception as e:
+            # Fallback to downloading tokenizer if local files not available
             self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
             self.tokenizer.save_pretrained(model)
 

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/fastsd/backend/openvino/latent_consistency_engine_advanced.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/fastsd/backend/openvino/latent_consistency_engine_advanced.py
@@ -107,7 +107,8 @@ class LatentConsistencyEngineAdvanced(DiffusionPipeline):
         super().__init__()
         try:
             self.tokenizer = CLIPTokenizer.from_pretrained(model, local_files_only=True)
-        except:
+        except Exception as e:
+            # Fallback to downloading tokenizer if local files not available
             self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
             self.tokenizer.save_pretrained(model)
 
@@ -461,7 +462,8 @@ class StableDiffusionEngineReferenceOnly(DiffusionPipeline):
         # self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
         try:
             self.tokenizer = CLIPTokenizer.from_pretrained(model, local_files_only=True)
-        except:
+        except Exception as e:
+            # Fallback to downloading tokenizer if local files not available
             self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
             self.tokenizer.save_pretrained(model)
 

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
@@ -95,7 +95,7 @@ def try_enable_npu_turbo(device, core):
         if all(arch not in architecture for arch in ["3700","3720"]):
             try:
                 core.set_property(properties={'NPU_TURBO': 'YES'},device_name='NPU')
-            except:
+            except Exception as e:
                 print(f"Failed loading NPU_TURBO for device {device}. Skipping... ")
             else:
                 print_npu_turbo_art()
@@ -111,7 +111,8 @@ class StableDiffusionEngineAdvanced(DiffusionPipeline):
                   device=["CPU", "CPU", "CPU", "CPU"]):
         try:
             self.tokenizer = CLIPTokenizer.from_pretrained(model, local_files_only=True)
-        except:
+        except Exception as e:
+            # Fallback to downloading tokenizer if local files not available
             self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
             self.tokenizer.save_pretrained(model)
 
@@ -260,14 +261,16 @@ class StableDiffusionEngineAdvanced(DiffusionPipeline):
                 #print("In transpose")
                 try:
                     latent_model_input = latent_model_input.permute(0,2,3,1)
-                except:
+                except AttributeError:
+                    # Fallback to NumPy transpose when PyTorch tensor not available
                     latent_model_input = latent_model_input.transpose(0,2,3,1)
 
             if self.unet_neg.input("latent_model_input").shape[1] != 4:
                 #print("In transpose")
                 try:
                     latent_model_input_neg = latent_model_input_neg.permute(0,2,3,1)
-                except:
+                except AttributeError:
+                    # Fallback to NumPy transpose when PyTorch tensor not available
                     latent_model_input_neg = latent_model_input_neg.transpose(0,2,3,1)
 
 
@@ -637,13 +640,15 @@ class StableDiffusionEngine(DiffusionPipeline):
                 if self.unet.input(self.unet_input_tensor_name).shape[1] != 4:
                     try:
                         latent_model_input_pos = latent_model_input_pos.permute(0,2,3,1)
-                    except:
+                    except AttributeError:
+                        # Fallback to NumPy transpose when PyTorch tensor not available
                         latent_model_input_pos = latent_model_input_pos.transpose(0,2,3,1)
                 
                 if self.unet_neg.input(self.unet_input_tensor_name).shape[1] != 4:
                     try:
                         latent_model_input_neg = latent_model_input_neg.permute(0,2,3,1)
-                    except:
+                    except AttributeError:
+                        # Fallback to NumPy transpose when PyTorch tensor not available
                         latent_model_input_neg = latent_model_input_neg.transpose(0,2,3,1)
                 
                 if "sample" in self.unet_input_tensor_name:                                        
@@ -812,7 +817,8 @@ class LatentConsistencyEngine(DiffusionPipeline):
         super().__init__()
         try:
             self.tokenizer = CLIPTokenizer.from_pretrained(model, local_files_only=True)
-        except:
+        except Exception as e:
+            # Fallback to downloading tokenizer if local files not available
             self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
             self.tokenizer.save_pretrained(model)
 

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine_inpainting.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine_inpainting.py
@@ -162,7 +162,8 @@ class StableDiffusionEngineInpainting(DiffusionPipeline):
         #self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
         try: 
             self.tokenizer = CLIPTokenizer.from_pretrained(model,local_files_only=True)
-        except:
+        except Exception as e:
+            # Fallback to downloading tokenizer if local files not available
             self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
             self.tokenizer.save_pretrained(model)
                 

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine_inpainting_advanced.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine_inpainting_advanced.py
@@ -169,7 +169,8 @@ class StableDiffusionEngineInpaintingAdvanced(DiffusionPipeline):
         #self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
         try: 
             self.tokenizer = CLIPTokenizer.from_pretrained(model,local_files_only=True)
-        except:
+        except Exception as e:
+            # Fallback to downloading tokenizer if local files not available
             self.tokenizer = CLIPTokenizer.from_pretrained(tokenizer)
             self.tokenizer.save_pretrained(model)
 

--- a/gimpopenvino/plugins/stable_diffusion_ov/stable_diffusion_ov.py
+++ b/gimpopenvino/plugins/stable_diffusion_ov/stable_diffusion_ov.py
@@ -224,7 +224,8 @@ def is_server_running():
             data = s.recv(config.SOCKET_BUFFER_SIZE)
             if data.decode() == "ping":
                 return True
-    except:
+    except (ConnectionError, OSError, socket.timeout) as e:
+        # Server not running or connection failed
         return False
 
     return False
@@ -236,7 +237,7 @@ def async_load_models(python_path, server_path, model_name, supported_devices, d
         s.sendall(b"kill")
 
         print("stable-diffusion model server killed")
-    except:
+    except (ConnectionError, OSError) as e:
         print("No stable-diffusion model server found to kill")
 
     if sys.platform == 'win32':
@@ -325,7 +326,8 @@ def run(procedure, run_mode, image, layer, config, data):
 
             try:
                 list_layers = image.get_layers()
-            except:
+            except AttributeError as e:
+                # Fallback for older GIMP API
                 list_layers = image.list_layers()
 
 


### PR DESCRIPTION
## Summary
Replace all bare `except:` clauses with specific exception types throughout the codebase to improve error handling, enable proper exception propagation, and follow Python best practices. Bare except clauses catch all exceptions including `SystemExit` and `KeyboardInterrupt`, making debugging difficult.

## Changes
- Replace bare `except:` with specific exception types (`ConnectionError`, `OSError`, `AttributeError`, `Exception`)
- Add clarifying comments for fallback behavior in tokenizer loading and tensor operations
- Improve socket error handling with specific connection-related exceptions
- Handle API compatibility differences between GIMP versions
- Ensure critical signals (`SystemExit`, `KeyboardInterrupt`) can propagate correctly

## Testing
- [ ] Verify socket-based server communication still handles connection failures gracefully
- [ ] Test tokenizer loading with missing local files triggers proper fallback to remote download
- [ ] Confirm tensor permutation fallback works with NumPy arrays
- [ ] Validate GIMP API compatibility layer works with multiple GIMP versions

---
**Related:** Code quality improvement - addressing Python anti-pattern