### PR TITLE
refactor: replace wildcard imports with explicit imports

### DIFF
--- a/gimpopenvino/plugins/openvino_utils/tools/model_manager.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/model_manager.py
@@ -23,7 +23,7 @@ logging.basicConfig(format='%(message)s', level=logging.INFO, stream=sys.stdout)
 sys.path.extend([os.path.join(os.path.dirname(os.path.realpath(__file__)), "openvino_common")])
 sys.path.extend([os.path.join(os.path.dirname(os.path.realpath(__file__)), "..","tools")])
 from models_ov import (stable_diffusion_engine_genai, stable_diffusion_engine_inpainting_genai)
-from gimpopenvino.install_utils import *
+from gimpopenvino.install_utils import NPUArchitecture, get_npu_architecture
 
 
 # This dictionary is used to populate the drop-down model selection list.

--- a/gimpopenvino/plugins/semseg_ov/semseg_ov.py
+++ b/gimpopenvino/plugins/semseg_ov/semseg_ov.py
@@ -18,7 +18,7 @@ import json
 import os
 import sys
 sys.path.extend([os.path.join(os.path.dirname(os.path.realpath(__file__)), "..","openvino_utils")])
-from plugin_utils import *
+from plugin_utils import show_dialog, save_image, N_
 from tools.tools_utils import base_model_dir, config_path_dir
 
 _ = gettext.gettext

--- a/gimpopenvino/plugins/stable_diffusion_ov/stable_diffusion_ov.py
+++ b/gimpopenvino/plugins/stable_diffusion_ov/stable_diffusion_ov.py
@@ -26,7 +26,7 @@ import glob
 from pathlib import Path
 
 sys.path.extend([os.path.join(os.path.dirname(os.path.realpath(__file__)), "..","openvino_utils")])
-from plugin_utils import *
+from plugin_utils import show_dialog, save_image, N_
 from model_management_window import ModelManagementWindow
 from tools.tools_utils import base_model_dir, config_path_dir, SDOptionCache
 import config

--- a/gimpopenvino/plugins/superresolution_ov/superresolution_ov.py
+++ b/gimpopenvino/plugins/superresolution_ov/superresolution_ov.py
@@ -15,7 +15,7 @@ import sys
 from enum import IntEnum
 
 sys.path.extend([os.path.join(os.path.dirname(os.path.realpath(__file__)), "..","openvino_utils")])
-from plugin_utils import *
+from plugin_utils import show_dialog, save_image
 
 gi.require_version("Gimp", "3.0")
 gi.require_version("GimpUi", "3.0")


### PR DESCRIPTION
## Summary
Replace all `from ... import *` statements with explicit named imports across plugin modules to improve code clarity, maintainability, and enable better IDE tooling support.

## Changes
- **model_manager.py**: Import `NPUArchitecture` and `get_npu_architecture` from `install_utils`
- **semseg_ov.py**: Import `show_dialog`, `save_image`, and `N_` from `plugin_utils`
- **stable_diffusion_ov.py**: Import `show_dialog`, `save_image`, and `N_` from `plugin_utils`
- **superresolution_ov.py**: Import `show_dialog` and `save_image` from `plugin_utils`

## Testing
- [ ] Verify all plugins load without import errors
- [ ] Test functionality of affected modules (model management, semantic segmentation, stable diffusion, super-resolution)